### PR TITLE
makefile: add goimports to tools bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ df-proto:
 
 df-master:
 	go build -o bin/master ./cmd/master
-	
+
 df-executor:
 	go build -o bin/executor ./cmd/executor
 

--- a/generate-proto.sh
+++ b/generate-proto.sh
@@ -71,4 +71,4 @@ cd ../pb || exit 1
 sed -i.bak -E 's/import _ \"gogoproto\"//g' *.pb.go
 sed -i.bak -E 's/import fmt \"fmt\"//g' *.pb.go
 rm -f *.bak
-goimports -w *.pb.go
+../tools/bin/goimports -w *.pb.go

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,4 +1,6 @@
-all: failpoint-ctl gocovmerge goveralls golangci-lint mockgen protoc-gen-gogofaster protoc-gen-grpc-gateway statik gofumports shfmt oapi-codegen gocov gocov-xml go-junit-report
+all: failpoint-ctl gocovmerge goveralls golangci-lint mockgen \
+	protoc-gen-gogofaster protoc-gen-grpc-gateway statik gofumports shfmt \
+	oapi-codegen gocov gocov-xml go-junit-report goimports
 
 failpoint-ctl:
 	go build -o bin/$@ github.com/pingcap/failpoint/failpoint-ctl
@@ -41,3 +43,6 @@ gocov-xml:
 
 go-junit-report:
 	go build -o bin/$@ github.com/jstemmer/go-junit-report
+
+goimports:
+	go build -o bin/$@ golang.org/x/tools/cmd/goimports


### PR DESCRIPTION
Fix make error from root directory

```
./generate-proto.sh: line 74: goimports: command not found
make: *** [Makefile:4: df-proto] Error 127
```