### PR TITLE
pkg: fix errors wrap, refine ToPBError, add unit test in errors lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,9 @@ require (
 	github.com/pingcap/failpoint v0.0.0-20210918120811-547c13e3eb00 // indirect
 	github.com/pingcap/ticdc v0.0.0-20211122030349-23c0c6dbd8a8
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.7.0
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20210512015243-d19fbe541bf9
+	go.uber.org/goleak v1.1.11-0.20210813005559-691160354723
 	go.uber.org/zap v1.19.1
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/grpc v1.40.0

--- a/go.sum
+++ b/go.sum
@@ -994,6 +994,7 @@ golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRu
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -24,7 +24,7 @@ var (
 	ErrTombstoneExecutor        = errors.Normalize("executor %d has been dead", errors.RFCCodeText("DFLOW:ErrTombstoneExecutor"))
 	ErrSubJobFailed             = errors.Normalize("executor %d job %d", errors.RFCCodeText("DFLOW:ErrSubJobFailed"))
 	ErrClusterResourceNotEnough = errors.Normalize("cluster resource is not enough, please scale out the cluster", errors.RFCCodeText("DFLOW:ErrClusterResourceNotEnough"))
-	ErrBuildJobFailed           = errors.Normalize("", errors.RFCCodeText("DFLOW:ErrBuildJobFailed"))
+	ErrBuildJobFailed           = errors.Normalize("build job failed", errors.RFCCodeText("DFLOW:ErrBuildJobFailed"))
 
 	ErrExecutorDupRegister = errors.Normalize("executor %d has been registered", errors.RFCCodeText("DFLOW:ErrExecutorDupRegister"))
 	ErrGrpcBuildConn       = errors.Normalize("dial grpc connection to %s failed", errors.RFCCodeText("DFLOW:ErrGrpcBuildConn"))

--- a/pkg/errors/helper_test.go
+++ b/pkg/errors/helper_test.go
@@ -1,0 +1,97 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	std_errors "errors"
+	"testing"
+
+	"github.com/hanfei1991/microcosom/pb"
+	"github.com/pingcap/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToPBError(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		err     error
+		pbError *pb.Error
+	}{
+		{
+			nil,
+			nil,
+		},
+		{
+			std_errors.New("non rfc error"),
+			&pb.Error{Code: pb.ErrorCode_UnknownError},
+		},
+		{
+			ErrUnknownExecutorID.FastGenByArgs(100),
+			&pb.Error{Code: pb.ErrorCode_UnknownExecutor},
+		},
+		{
+			ErrTombstoneExecutor.FastGenByArgs(101),
+			&pb.Error{Code: pb.ErrorCode_TombstoneExecutor},
+		},
+		{
+			ErrSubJobFailed.FastGenByArgs(102, 103),
+			&pb.Error{Code: pb.ErrorCode_SubJobSubmitFailed},
+		},
+		{
+			ErrClusterResourceNotEnough.FastGenByArgs(),
+			&pb.Error{Code: pb.ErrorCode_NotEnoughResource},
+		},
+		{
+			ErrBuildJobFailed.FastGenByArgs(),
+			&pb.Error{Code: pb.ErrorCode_SubJobBuildFailed},
+		},
+		{
+			ErrHeartbeat.FastGenByArgs("logic"),
+			&pb.Error{Code: pb.ErrorCode_UnknownError},
+		},
+	}
+	for _, tc := range testCases {
+		if tc.err != nil {
+			tc.pbError.Message = tc.err.Error()
+		}
+		require.Equal(t, tc.pbError, ToPBError(tc.err))
+	}
+}
+
+func TestWrapError(t *testing.T) {
+	t.Parallel()
+	var (
+		err       = errors.New("test")
+		testCases = []struct {
+			rfcError *errors.Error
+			err      error
+			isNil    bool
+			expected string
+			args     []interface{}
+		}{
+			{ErrBuildJobFailed, nil, true, "", []interface{}{}},
+			{ErrBuildJobFailed, err, false, "[DFLOW:ErrBuildJobFailed]build job failed: test", []interface{}{}},
+			{ErrSubJobFailed, err, false, "[DFLOW:ErrSubJobFailed]executor 1 job 2: test", []interface{}{1, 2}},
+		}
+	)
+	for _, tc := range testCases {
+		we := Wrap(tc.rfcError, tc.err, tc.args...)
+		if tc.isNil {
+			require.Nil(t, we)
+		} else {
+			require.NotNil(t, we)
+			require.Equal(t, tc.expected, we.Error())
+		}
+	}
+}

--- a/pkg/errors/main_test.go
+++ b/pkg/errors/main_test.go
@@ -1,0 +1,24 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"testing"
+
+	"github.com/hanfei1991/microcosom/pkg/leakutil"
+)
+
+func TestMain(m *testing.M) {
+	leakutil.SetUpLeakTest(m)
+}

--- a/pkg/leakutil/leak_helper.go
+++ b/pkg/leakutil/leak_helper.go
@@ -1,0 +1,33 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leakutil
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// SetUpLeakTest ignore unexpected common etcd and opencensus stack functions for goleak
+// options can be used to implement other ignore items
+func SetUpLeakTest(m *testing.M, options ...goleak.Option) {
+	opts := []goleak.Option{
+		// Can add any ignorable goroutine, such as
+		// goleak.IgnoreTopFunction("go.etcd.io/etcd/pkg/logutil.(*MergeLogger).outputLoop"),
+	}
+
+	opts = append(opts, options...)
+
+	goleak.VerifyTestMain(m, opts...)
+}

--- a/pkg/leakutil/leak_helper_test.go
+++ b/pkg/leakutil/leak_helper_test.go
@@ -1,0 +1,36 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leakutil
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestSetUpLeakTest(t *testing.T) {
+	leakChan := make(chan interface{})
+
+	go func() {
+		<-leakChan
+	}()
+}
+
+func TestMain(m *testing.M) {
+	opts := []goleak.Option{
+		goleak.IgnoreTopFunction("github.com/hanfei1991/microcosom/pkg/leakutil.TestSetUpLeakTest.func1"),
+	}
+
+	SetUpLeakTest(m, opts...)
+}


### PR DESCRIPTION
1. Use cdc_errors.RFCCode to check rfc error
2. Use `return rfcError.Wrap(err).GenWithStackByArgs(args...)` to return rfc error wrap
3. Add unit test in errors library.